### PR TITLE
Feature/new content pages

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -340,27 +340,21 @@ let router = new Router({
                 import("@/views/admin/index/cms/frontend/PrivacyPolicy")
             },
             {
-              path: "frontend/about",
-              name: "admin-index-cms-frontend-about",
-              component: () => import("@/views/admin/index/cms/frontend/About")
-            },
-            {
               path: "frontend/contact",
               name: "admin-index-cms-frontend-contact",
               component: () =>
                 import("@/views/admin/index/cms/frontend/Contact")
             },
             {
-              path: "frontend/get-involved",
-              name: "admin-index-cms-frontend-get-involved",
-              component: () =>
-                import("@/views/admin/index/cms/frontend/GetInvolved")
-            },
-            {
               path: "frontend/favourites",
               name: "admin-index-cms-frontend-favourites",
               component: () =>
                 import("@/views/admin/index/cms/frontend/Favourites")
+            },
+            {
+              path: "frontend/page/:pageSlug",
+              name: "admin-index-cms-frontend-page",
+              component: () => import("@/views/admin/index/cms/frontend/Page")
             }
           ]
         },

--- a/src/views/admin/index/Cms.vue
+++ b/src/views/admin/index/Cms.vue
@@ -54,16 +54,36 @@ export default {
           to: { name: "admin-index-cms-frontend-privacy-policy" }
         },
         {
-          heading: "About",
-          to: { name: "admin-index-cms-frontend-about" }
+          heading: "About Connect",
+          to: {
+            name: "admin-index-cms-frontend-page",
+            params: { pageSlug: "about_connect", pageTitle: "About Connect" }
+          }
+        },
+        {
+          heading: "Providers",
+          to: {
+            name: "admin-index-cms-frontend-page",
+            params: { pageSlug: "providers", pageTitle: "Providers" }
+          }
+        },
+        {
+          heading: "Supporters",
+          to: {
+            name: "admin-index-cms-frontend-page",
+            params: { pageSlug: "supporters", pageTitle: "Supporters" }
+          }
+        },
+        {
+          heading: "Funders",
+          to: {
+            name: "admin-index-cms-frontend-page",
+            params: { pageSlug: "funders", pageTitle: "Funders" }
+          }
         },
         {
           heading: "Contact",
           to: { name: "admin-index-cms-frontend-contact" }
-        },
-        {
-          heading: "Get Involved",
-          to: { name: "admin-index-cms-frontend-get-involved" }
         },
         {
           heading: "Favourites",

--- a/src/views/admin/index/Cms.vue
+++ b/src/views/admin/index/Cms.vue
@@ -57,7 +57,7 @@ export default {
           heading: "About Connect",
           to: {
             name: "admin-index-cms-frontend-page",
-            params: { pageSlug: "about_connect", pageTitle: "About Connect" }
+            params: { pageSlug: "about", pageTitle: "About Connect" }
           }
         },
         {

--- a/src/views/admin/index/cms/frontend/Page.vue
+++ b/src/views/admin/index/cms/frontend/Page.vue
@@ -1,34 +1,26 @@
 <template>
   <gov-grid-row>
     <gov-grid-column width="two-thirds">
-      <gov-heading size="l">About</gov-heading>
+      <gov-heading size="l">{{$route.params.pageTitle}}</gov-heading>
 
-      <gov-body>Review the content for the about page on the frontend.</gov-body>
+      <gov-body>Review the content for the {{$route.params.pageTitle}} page on the frontend.</gov-body>
 
       <ck-text-input
-        :value="frontend.about.title"
+        :key="'frontend-' + $route.params.pageSlug + '-title'"
+        :value="frontend[$route.params.pageSlug].title"
         @input="onInput({ field: 'title', value: $event })"
         label="Title"
-        :error="errors.get('cms.frontend.about.title')"
-        id="cms.frontend.about.title"
+        :error="errors.get('cms.frontend[$route.params.pageSlug].title')"
+        id="cms.frontend[$route.params.pageSlug].title"
       />
 
       <ck-wysiwyg-input
-        :value="frontend.about.content"
+        :key="'frontend-' + $route.params.pageSlug + '-content'"
+        :value="frontend[$route.params.pageSlug].content"
         @input="onInput({ field: 'content', value: $event })"
         label="Content"
-        :error="errors.get('cms.frontend.about.content')"
-        id="cms.frontend.about.content"
-      />
-
-      <ck-text-input
-        :value="frontend.about.video_url"
-        @input="onInput({ field: 'video_url', value: $event })"
-        label="Video URL"
-        hint="Only YoutTube and Vimeo URLs supported."
-        :error="errors.get('cms.frontend.about.video_url')"
-        id="cms.frontend.about.video_url"
-        type="url"
+        :error="errors.get('cms.frontend[$route.params.pageSlug].content')"
+        id="cms.frontend[$route.params.pageSlug].content"
       />
     </gov-grid-column>
   </gov-grid-row>
@@ -59,7 +51,7 @@ export default {
     onInput({ field, value }) {
       const frontend = { ...this.frontend };
 
-      frontend.about[field] = value;
+      frontend[this.$route.params.pageSlug][field] = value;
 
       this.$emit("input", frontend);
       this.$emit("clear", `frontend.about.${field}`);

--- a/src/views/admin/index/cms/frontend/Page.vue
+++ b/src/views/admin/index/cms/frontend/Page.vue
@@ -54,7 +54,7 @@ export default {
       frontend[this.$route.params.pageSlug][field] = value;
 
       this.$emit("input", frontend);
-      this.$emit("clear", `frontend.about.${field}`);
+      this.$emit("clear", `frontend.${this.$route.params.pageSlug}.${field}`);
     }
   }
 };


### PR DESCRIPTION
### Summary
https://trello.com/c/biMeXjz6

- Rename About to About Connect and remove video field
- Add 3 new pages; Providers, Supporters and Funders
- Used dynamic route matching to re-use same view. Renamed About.vue to Page.vue for this purpose.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
The use of tabs to move between pages is breaking down due to the number of pages. An alternative page navigation should be implemented.
