### PR TITLE
Feature/show session timeout value in message

### DIFF
--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -28,15 +28,15 @@
 </template>
 
 <script>
-import Auth from '@/classes/Auth';
+import Auth from "@/classes/Auth";
 
 export default {
-  name: 'Login',
+  name: "Login",
   data() {
     return {
       accessToken:
         Auth.parseQueryString(window.location.href).access_token || null,
-      expiresIn: Auth.parseQueryString(window.location.href).expires_in || null,
+      expiresIn: Auth.parseQueryString(window.location.href).expires_in || null
     };
   },
   computed: {
@@ -56,19 +56,19 @@ export default {
     },
     sessionTimeout() {
       return process.env.VUE_APP_SESSION_TIMEOUT;
-    },
+    }
   },
   methods: {
     async login() {
       await Auth.login(this.accessToken, this.expiresIn);
-      this.$root.$emit('login');
-      this.$router.push({ name: 'dashboard' });
-    },
+      this.$root.$emit("login");
+      this.$router.push({ name: "dashboard" });
+    }
   },
   created() {
     if (this.validateRequest) {
       this.login();
     }
-  },
+  }
 };
 </script>

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -17,7 +17,7 @@
             <gov-button :href="loginUrl">Login</gov-button>
 
             <gov-body size="s">
-              For security reasons, you will be automatically logged out after 20 minutes.
+              For security reasons, you will be automatically logged out after {{ sessionTimeout }} minutes.
             </gov-body>
           </template>
 
@@ -28,15 +28,15 @@
 </template>
 
 <script>
-import Auth from "@/classes/Auth";
+import Auth from '@/classes/Auth';
 
 export default {
-  name: "Login",
+  name: 'Login',
   data() {
     return {
       accessToken:
         Auth.parseQueryString(window.location.href).access_token || null,
-      expiresIn: Auth.parseQueryString(window.location.href).expires_in || null
+      expiresIn: Auth.parseQueryString(window.location.href).expires_in || null,
     };
   },
   computed: {
@@ -53,19 +53,22 @@ export default {
       }
 
       return true;
-    }
+    },
+    sessionTimeout() {
+      return process.env.VUE_APP_SESSION_TIMEOUT;
+    },
   },
   methods: {
     async login() {
       await Auth.login(this.accessToken, this.expiresIn);
-      this.$root.$emit("login");
-      this.$router.push({ name: "dashboard" });
-    }
+      this.$root.$emit('login');
+      this.$router.push({ name: 'dashboard' });
+    },
   },
   created() {
     if (this.validateRequest) {
       this.login();
     }
-  }
+  },
 };
 </script>


### PR DESCRIPTION
### Summary
https://trello.com/c/6cB63dqD

Changed Login session timeout warning to use the value from .env to show length of session

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
The client has requested the session timeout value be set to 35 minutes. Once this is deployed this can be manually set in .env via VUE_APP_SESSION_TIMEOUT

### Notes
NA
