### PR TITLE
Replaced Connected Together > Connect, service > support listing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VUE_APP_NAME=Connected Together
+VUE_APP_NAME=Connect
 VUE_APP_ENV=local
 VUE_APP_URI=
 VUE_APP_FRONTEND_URI=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Connected Together - Admin
+# Connect - Admin
+
 This is a [Vue.js](https://vuejs.org/) SPA (Single Page App) using [Vue Router](https://router.vuejs.org) for the routing. Therefore, a good knowledge of both Vue.js and Vue Router is expected when working on this project.
 
 This is a static site that is intended to be hosted on an amazon S3 bucket.
@@ -6,6 +7,7 @@ This is a static site that is intended to be hosted on an amazon S3 bucket.
 All logic is handled by [the API](https://github.com/Healthy-London-Partnership/api) - so you can think of this app as purely an interface for the API.
 
 ## Installation
+
 ```bash
 # Copy the example .env and fill in the empty variables.
 cp .env.example .env
@@ -15,12 +17,14 @@ npm install
 ```
 
 ### Development
+
 ```bash
 # Start a development server with hot-reload.
 npm run serve
 ```
 
 ### Test
+
 ```bash
 # Run the linter and automatically fix any issues.
 npm run lint --fix
@@ -33,6 +37,7 @@ npm run test:e2e
 ```
 
 ## Deploy
+
 Deployment is handled automatically with CI/CD using TravisCI.
 Below is the commands that TraviCI uses to build the application.
 
@@ -41,18 +46,23 @@ npm run build
 ```
 
 ## Built With
-* [Vue.js](https://vuejs.org/) - The JavaScript Framework Used
+
+- [Vue.js](https://vuejs.org/) - The JavaScript Framework Used
 
 ## Contributing
+
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Versioning
+
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/Healthy-London-Partnership/admin/tags).
 
 ## Authors
-* [Ayup Digital](https://ayup.agency/)
+
+- [Ayup Digital](https://ayup.agency/)
 
 See also the list of [contributors](https://github.com/Healthy-London-Partnership/admin/contributors) who participated in this project.
 
 ## License
+
 This project is licensed under the GNU AGPLv3 License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@ export default {
     },
     loggedInItems() {
       return [
-        { text: "Services", to: { name: "services-index" } },
+        { text: "Support Listings", to: { name: "services-index" } },
         { text: "Locations", to: { name: "locations-index" } },
         { text: "Referrals", to: { name: "referrals-index" } },
         { text: "Organisations", to: { name: "organisations-index" } },

--- a/src/components/CkNotificationDetails.vue
+++ b/src/components/CkNotificationDetails.vue
@@ -63,7 +63,7 @@ export default {
         case "referrals":
           return "Referral";
         case "services":
-          return "Service";
+          return "Support Listing";
         case null:
           return "-";
         default:

--- a/src/components/CkNotificationsTable.vue
+++ b/src/components/CkNotificationsTable.vue
@@ -56,7 +56,7 @@ export default {
         case "referrals":
           return "Referral";
         case "services":
-          return "Service";
+          return "Support Listing";
         case null:
           return "-";
         default:

--- a/src/components/CkServiceLocationsTable.vue
+++ b/src/components/CkServiceLocationsTable.vue
@@ -20,7 +20,7 @@
         </gov-table-cell>
       </gov-table-row>
       <gov-table-row v-if="serviceLocations.length === 0">
-        <gov-table-cell center colspan="5">No locations for this service</gov-table-cell>
+        <gov-table-cell center colspan="5">No locations for this support listing</gov-table-cell>
       </gov-table-row>
     </template>
   </gov-table>

--- a/src/components/CkUserDetails.vue
+++ b/src/components/CkUserDetails.vue
@@ -50,8 +50,8 @@
               </gov-details>
             </li>
             <li>
-              <template v-if="serviceAdmin.length === 0">Service admin: No</template>
-              <gov-details v-else summary="Service admin: Yes" class="no-margin">
+              <template v-if="serviceAdmin.length === 0">Support listing admin: No</template>
+              <gov-details v-else summary="Support Listing admin: Yes" class="no-margin">
                 <div v-for="(role, key) in serviceAdmin" :key="key">
                   <gov-link
                     :to="{ name: 'services-show', params: { service: role.service_id } }"
@@ -61,8 +61,8 @@
               </gov-details>
             </li>
             <li>
-              <template v-if="serviceWorker.length === 0">Service worker: No</template>
-              <gov-details v-else summary="Service worker: Yes" class="no-margin">
+              <template v-if="serviceWorker.length === 0">Support listing worker: No</template>
+              <gov-details v-else summary="Support Listing worker: Yes" class="no-margin">
                 <div v-for="(role, key) in serviceWorker" :key="key">
                   <gov-link
                     :to="{ name: 'services-show', params: { service: role.service_id } }"

--- a/src/main.js
+++ b/src/main.js
@@ -214,6 +214,7 @@ Vue.mixin({
     },
     plural(string) {
       const plurals = {
+        listing: "listings",
         service: "services",
         activity: "activities",
         club: "clubs",

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -11,7 +11,7 @@
 
           <gov-body size="l">
             From here, you can add and edit your pages on {{appName}}, as
-            well as manage referrals into your service. For any support, contact
+            well as manage referrals into your support listing. For any support, contact
             <gov-link href="mailto:info@connectedtogether.org.uk">
               info@connectedtogether.org.uk
             </gov-link>
@@ -23,17 +23,17 @@
 
       <gov-grid-row>
         <gov-grid-column width="one-half">
-          <gov-heading size="l">Services</gov-heading>
+          <gov-heading size="l">Support Listings</gov-heading>
           <gov-body>Add or edit your pages on {{appName}}.</gov-body>
           <gov-button start :to="{ name: 'services-index' }">
-            Go to services
+            Go to support listings
           </gov-button>
           <gov-section-break size="m" />
         </gov-grid-column>
 
         <gov-grid-column width="one-half">
           <gov-heading size="l">Locations</gov-heading>
-          <gov-body>View and edit service locations in the Borough.</gov-body>
+          <gov-body>View and edit support listing locations in the Borough.</gov-body>
           <gov-button start :to="{ name: 'locations-index' }">
             Go to locations
           </gov-button>
@@ -42,7 +42,7 @@
 
         <gov-grid-column width="one-half">
           <gov-heading size="l">Referrals</gov-heading>
-          <gov-body>View and respond to referrals to your service(s).</gov-body>
+          <gov-body>View and respond to referrals to your support listing(s).</gov-body>
           <gov-button start :to="{ name: 'referrals-index' }">
             Go to referrals
           </gov-button>

--- a/src/views/admin/index/taxonomies/Categories.vue
+++ b/src/views/admin/index/taxonomies/Categories.vue
@@ -5,13 +5,13 @@
         <gov-heading size="l">Taxonomy: Categories</gov-heading>
 
         <gov-body>
-          Taxonomies are the 'tags' that we assign to services, in order for them to appear
+          Taxonomies are the 'tags' that we assign to support listings, in order for them to appear
           within search results and categories. They are pulled from the
           <gov-link href="https://about.auntbertha.com/openeligibility">Aunt Bertha Open Eligibility Standard</gov-link>.
         </gov-body>
 
         <gov-body>
-          From this page, you can edit the taxonomies available to be applied to a service, as well as add new ones.
+          From this page, you can edit the taxonomies available to be applied to a support listing, as well as add new ones.
         </gov-body>
       </gov-grid-column>
 

--- a/src/views/admin/index/taxonomies/Organisations.vue
+++ b/src/views/admin/index/taxonomies/Organisations.vue
@@ -5,7 +5,7 @@
         <gov-heading size="l">Taxonomy: Organisations</gov-heading>
 
         <gov-body>
-          This page shows the list of organisations a user can select from when referring a client to another service.
+          This page shows the list of organisations a user can select from when referring a client to another support listing.
           Essentially, these are the organisations a champion can refer 'from'.
         </gov-body>
 

--- a/src/views/collections/forms/CollectionForm.vue
+++ b/src/views/collections/forms/CollectionForm.vue
@@ -26,7 +26,7 @@
       @input="$emit('update:intro', $event); $emit('clear', 'intro')"
       id="intro"
       :label="`Description of ${type}`"
-      :hint="`A short summary detailing what type of services the ${type} contains.`"
+      :hint="`A short summary detailing what type of support listings the ${type} contains.`"
       :maxlength="150"
       :error="errors.get('intro')"
     />

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -25,7 +25,7 @@
       @input="$emit('update:intro', $event); $emit('clear', 'intro')"
       id="intro"
       label="Description of category"
-      hint="A short summary detailing what type of services the persona includes."
+      hint="A short summary detailing what type of support listings the persona includes."
       :maxlength="150"
       :error="errors.get('intro')"
     />

--- a/src/views/locations/Create.vue
+++ b/src/views/locations/Create.vue
@@ -8,7 +8,7 @@
         <gov-grid-column width="one-half">
           <gov-heading size="xl">Locations</gov-heading>
           <gov-heading size="m">Add location</gov-heading>
-          <gov-body>The locations will appear on the service pages which will inform people of where to find your service/organisation</gov-body>
+          <gov-body>The locations will appear on the support listing pages which will inform people of where to find your support listing/organisation</gov-body>
 
           <location-form
             :errors="form.$errors"

--- a/src/views/locations/Edit.vue
+++ b/src/views/locations/Edit.vue
@@ -10,7 +10,7 @@
           <gov-grid-column width="one-half">
             <gov-heading size="xl">Locations</gov-heading>
             <gov-heading size="m">Edit location</gov-heading>
-            <gov-body>The locations will appear on the service pages which will inform people of where to find your service/organisation</gov-body>
+            <gov-body>The locations will appear on the support listing pages which will inform people of where to find your support listing/organisation</gov-body>
 
             <location-form
               :errors="form.$errors"

--- a/src/views/organisation-admin-invites/Start.vue
+++ b/src/views/organisation-admin-invites/Start.vue
@@ -17,7 +17,7 @@
           </gov-body>
 
           <gov-body>
-            This service is completely free, will improve your organisation's
+            This support listing is completely free, will improve your organisation's
             profile, give you access to new funding opportunities and help
             improve people's access to the support you offer.
           </gov-body>
@@ -29,7 +29,7 @@
           <gov-list type="ordered" number>
             <li>Create an account</li>
             <li>Review your data</li>
-            <li>Adding service(s)</li>
+            <li>Adding support listing(s)</li>
             <li>Manage account</li>
           </gov-list>
 

--- a/src/views/organisation-admin-invites/Submitted.vue
+++ b/src/views/organisation-admin-invites/Submitted.vue
@@ -29,12 +29,12 @@
           <gov-body>
             Once you've confirmed you email address, you'll be able to claim
             your listing and be able to start editing your organisation details
-            and adding services that your organisation offers. This can take up
+            and adding support listings that your organisation offers. This can take up
             to 20 minutes.
           </gov-body>
 
           <gov-body>
-            Once you have added one service, your listing will be visible for
+            Once you have added one support listing, your listing will be visible for
             anyone to see.
           </gov-body>
 

--- a/src/views/organisations/Create.vue
+++ b/src/views/organisations/Create.vue
@@ -8,7 +8,7 @@
         <gov-grid-column width="one-half">
           <gov-heading size="xl">Organisations</gov-heading>
           <gov-heading size="m">Add organisation</gov-heading>
-          <gov-body>General details about the organisation. To be found when searching or linked from a service page.</gov-body>
+          <gov-body>General details about the organisation. To be found when searching or linked from a support listing page.</gov-body>
 
           <organisation-form
             :errors="form.$errors"

--- a/src/views/organisations/Edit.vue
+++ b/src/views/organisations/Edit.vue
@@ -10,7 +10,7 @@
           <gov-grid-column width="one-half">
             <gov-heading size="xl">Organisations</gov-heading>
             <gov-heading size="m">Edit organisation</gov-heading>
-            <gov-body>General details about the organisation. To be found when searching or linked from a service page.</gov-body>
+            <gov-body>General details about the organisation. To be found when searching or linked from a support listing page.</gov-body>
 
             <organisation-form
               :errors="form.$errors"

--- a/src/views/organisations/Index.vue
+++ b/src/views/organisations/Index.vue
@@ -51,7 +51,7 @@
                   </gov-form-group>
 
                   <gov-form-group>
-                    <gov-label for="filter[has_services]">Has services</gov-label>
+                    <gov-label for="filter[has_services]">Has Support listings</gov-label>
                     <gov-select
                       v-model="filters.has_services"
                       id="filter[has_services]"

--- a/src/views/pending-organisation-admins/Confirm.vue
+++ b/src/views/pending-organisation-admins/Confirm.vue
@@ -22,16 +22,16 @@
 
           <gov-body>
             We recommend a quick check of your organisation's details and then
-            going straight on to adding once service. Maybe start with the
-            service that's easiest to describe or that you know best.
+            going straight on to adding once support listing. Maybe start with the
+            support listing that's easiest to describe or that you know best.
           </gov-body>
 
           <gov-heading size="l">
-            Add a service
+            Add a support listing
           </gov-heading>
 
           <gov-body>
-            Once you've added one service, your listing will be live and can be
+            Once you've added one support listing, your listing will be live and can be
             viewed by GPs and other professionals who might want to make
             referrals, plus people who access NHS Connect through a wide range
             of different websites and social media channels.

--- a/src/views/referrals/Index.vue
+++ b/src/views/referrals/Index.vue
@@ -18,7 +18,7 @@
 
                 <template slot="extra-filters">
                   <gov-form-group>
-                    <gov-label for="filter[service_name]">Service name</gov-label>
+                    <gov-label for="filter[service_name]">Support listing name</gov-label>
                     <gov-input v-model="filters.service_name" id="filter[service_name]" name="filter[service_name]" type="search"/>
                   </gov-form-group>
 
@@ -52,7 +52,7 @@
             default-sort="-created_at"
             :columns="[
               { heading: 'Reference no.', sort: 'reference' },
-              { heading: 'Service', sort: 'service_name' },
+              { heading: 'Support listing', sort: 'service_name' },
               { heading: 'Referred by' },
               { heading: 'Status' },
               { heading: 'Date submitted', sort: 'created_at' },

--- a/src/views/register/index/Eligibility.vue
+++ b/src/views/register/index/Eligibility.vue
@@ -8,11 +8,11 @@
       <gov-grid-row>
         <gov-grid-column width="two-thirds">
           <gov-heading size="l">
-            Is your service right for {{appName}}?
+            Is your support listing right for {{appName}}?
           </gov-heading>
 
           <gov-body>
-            We have some criteria for information, services and organisations
+            We have some criteria for information, support listings and organisations
             that are listed on the site.
           </gov-body>
 
@@ -32,7 +32,7 @@
                 :value="form.organisation_types.includes('community')"
                 id="organisation_types.community"
                 name="organisation_types"
-                label="A community, voluntary or faith-based service (not proselytising) e.g. a charity, a C.I.C., or a social enterprise"
+                label="A community, voluntary or faith-based support listing (not proselytising) e.g. a charity, a C.I.C., or a social enterprise"
                 @input="$emit('input', onInput('community'))"
               />
 
@@ -40,7 +40,7 @@
                 :value="form.organisation_types.includes('council')"
                 id="organisation_types.council"
                 name="organisation_types"
-                label="A council or other statutory or governmental service, e.g. services delivered by the NHS or a local authority"
+                label="A council or other statutory or governmental support listing, e.g. support listings delivered by the NHS or a local authority"
                 @input="$emit('input', onInput('council'))"
               />
 
@@ -48,7 +48,7 @@
                 :value="form.organisation_types.includes('commercial')"
                 id="organisation_types.commercial"
                 name="organisation_types"
-                label="A commercial provider offering services that support health, wellbeing and/or community for free or a reasonable charge"
+                label="A commercial provider offering support listings that support health, wellbeing and/or community for free or a reasonable charge"
                 @input="$emit('input', onInput('commercial'))"
               />
 
@@ -56,7 +56,7 @@
                 :value="form.organisation_types.includes('commercial_contracted')"
                 id="organisation_types.commercial_contracted"
                 name="organisation_types"
-                label="A commercial service that is contracted or spot purchased under a commissioning arrangement with a local authority, intended to improve the health, wellbeing or independence of residents"
+                label="A commercial support listing that is contracted or spot purchased under a commissioning arrangement with a local authority, intended to improve the health, wellbeing or independence of residents"
                 @input="$emit('input', onInput('commercial_contracted'))"
               />
             </gov-checkboxes>

--- a/src/views/register/index/Organisation.vue
+++ b/src/views/register/index/Organisation.vue
@@ -8,12 +8,12 @@
       <gov-grid-row>
         <gov-grid-column width="two-thirds">
           <gov-heading size="l">
-            What organisation runs this service?
+            What organisation runs this support listing?
           </gov-heading>
 
           <gov-body>
             If you are a smaller group or activity that isn't directly run by an
-            organisation, you can enter details about your service/group below.
+            organisation, you can enter details about your support listing/group below.
           </gov-body>
 
           <ck-text-input

--- a/src/views/register/index/Success.vue
+++ b/src/views/register/index/Success.vue
@@ -4,7 +4,7 @@
       <gov-grid-row>
         <gov-grid-column width="two-thirds">
           <gov-heading size="l">
-            Thank you for adding your service to {{appName}}
+            Thank you for adding your support listing to {{appName}}
           </gov-heading>
 
           <gov-body>

--- a/src/views/register/index/forms/AdditionalInfoTab.vue
+++ b/src/views/register/index/forms/AdditionalInfoTab.vue
@@ -50,7 +50,7 @@
           <template slot="hint">
             <gov-hint for="is_free">
               Indicates whether your {{ service.type }} is completely free, or
-              if some elements of the service must be paid for. Users can filter
+              if some elements of the support listing must be paid for. Users can filter
               their searches based on the answer you provide.
             </gov-hint>
 
@@ -95,7 +95,7 @@
         >
           <template slot="hint">
               <gov-hint for="testimonial">
-                Please enter a quote from a service user highlighting a positive
+                Please enter a quote from a support listing user highlighting a positive
                 outcome to help promote your good work. For example:
               </gov-hint>
 

--- a/src/views/register/index/forms/DetailsTab.vue
+++ b/src/views/register/index/forms/DetailsTab.vue
@@ -5,7 +5,7 @@
       <gov-grid-column width="one-half">
 
         <gov-body>
-          General details about the service (we use service in the broadest
+          General details about the support listing (we use support listing in the broadest
           sense, this could be counselling, a website, or an app).
         </gov-body>
 

--- a/src/views/register/index/forms/WhoForTab.vue
+++ b/src/views/register/index/forms/WhoForTab.vue
@@ -22,7 +22,7 @@
           "
           :error="errors.get('service.criteria.age_group')"
           id="criteria.age_group"
-          label="Age of service user (if applicable)"
+          label="Age of support listing user (if applicable)"
           :hint="`E.g “This ${service.type} is for people 16+” or “This ${service.type} is aimed at people nearing retirement”`"
         />
         <!-- /Age group -->

--- a/src/views/reports/Edit.vue
+++ b/src/views/reports/Edit.vue
@@ -90,9 +90,9 @@ export default {
         },
         {
           type: "Locations Export",
-          description: `Generate a report with all the locations of services on ${
+          description: `Generate a report with all the locations of support listings on ${
             process.env.VUE_APP_NAME
-          }, and the number of services delivered at each.`,
+          }, and the number of support listings delivered at each.`,
           scheduleForm: new Form({
             report_type: "Locations Export",
             repeat_type: null
@@ -107,7 +107,7 @@ export default {
           type: "Organisations Export",
           description: `Generate a report of all the organisations on ${
             process.env.VUE_APP_NAME
-          } with the number of services and attributed accounts.`,
+          } with the number of support listings and attributed accounts.`,
           scheduleForm: new Form({
             report_type: "Organisations Export",
             repeat_type: null
@@ -151,7 +151,7 @@ export default {
         {
           type: "Services Export",
           description:
-            "Generate a list of all services, including contact " +
+            "Generate a list of all support listings, including contact " +
             "details, whether they have referrals enabled, the last time " +
             "updated, contact details etc.",
           scheduleForm: new Form({

--- a/src/views/service-locations/Create.vue
+++ b/src/views/service-locations/Create.vue
@@ -4,12 +4,12 @@
     <template v-else>
       <vue-headful :title="`${appName} - Add Service Location for: ${service.name}`" />
 
-      <gov-back-link :to="{ name: 'services-show-locations', params: { service: service.id } }">Back to service</gov-back-link>
+      <gov-back-link :to="{ name: 'services-show-locations', params: { service: service.id } }">Back to support listing</gov-back-link>
       <gov-main-wrapper>
         <gov-grid-row>
           <gov-grid-column width="one-half">
-            <gov-heading size="xl">Service locations</gov-heading>
-            <gov-heading size="m">Add service location</gov-heading>
+            <gov-heading size="xl">Support listing locations</gov-heading>
+            <gov-heading size="m">Add support listing location</gov-heading>
 
             <service-location-form
               :errors="form.$errors"
@@ -102,7 +102,7 @@ export default {
           this.form.location_id = location.id;
         }
 
-        // Post the service location.
+        // Post the support listing location.
         const { data: service } = await this.form.post("/service-locations");
         this.$router.push({
           name: "service-locations-show",

--- a/src/views/service-locations/Edit.vue
+++ b/src/views/service-locations/Edit.vue
@@ -2,14 +2,14 @@
   <gov-width-container>
     <ck-loader v-if="loading" />
     <template v-else>
-      <vue-headful :title="`${appName} - Edit Service Location: ${serviceLocation.name || '-'}`" />
+      <vue-headful :title="`${appName} - Edit Support listing Location: ${serviceLocation.name || '-'}`" />
 
-      <gov-back-link :to="{ name: 'service-locations-show', params: { serviceLocation: serviceLocation.id } }">Back to service location</gov-back-link>
+      <gov-back-link :to="{ name: 'service-locations-show', params: { serviceLocation: serviceLocation.id } }">Back to support listing location</gov-back-link>
       <gov-main-wrapper>
         <gov-grid-row>
           <gov-grid-column width="one-half">
-            <gov-heading size="xl">Service locations</gov-heading>
-            <gov-heading size="m">Edit service location</gov-heading>
+            <gov-heading size="xl">Support listing locations</gov-heading>
+            <gov-heading size="m">Edit support listing location</gov-heading>
 
             <service-location-form
               :errors="form.$errors"

--- a/src/views/service-locations/Show.vue
+++ b/src/views/service-locations/Show.vue
@@ -2,19 +2,19 @@
   <gov-width-container>
     <ck-loader v-if="loading" />
     <template v-else>
-      <vue-headful :title="`${appName} - Service Location: ${serviceLocation.name || '-'}`" />
+      <vue-headful :title="`${appName} - Support listing Location: ${serviceLocation.name || '-'}`" />
 
-      <gov-back-link :to="{ name: 'services-show-locations', params: { service: serviceLocation.service_id } }">Back to service</gov-back-link>
+      <gov-back-link :to="{ name: 'services-show-locations', params: { service: serviceLocation.service_id } }">Back to support listing</gov-back-link>
       <gov-main-wrapper>
         <gov-grid-row>
           <gov-grid-column width="two-thirds">
 
-            <gov-heading size="m">View service location</gov-heading>
+            <gov-heading size="m">View support listing location</gov-heading>
 
             <service-location-details :service-location="serviceLocation" />
 
             <template v-if="auth.isServiceAdmin(serviceLocation.service)">
-              <gov-body>Please be certain of the action before deleting a service location</gov-body>
+              <gov-body>Please be certain of the action before deleting a support listing location</gov-body>
 
               <gov-section-break size="l" />
 
@@ -29,7 +29,7 @@
           <gov-grid-column v-if="auth.isServiceAdmin(serviceLocation.service)" width="one-third" class="text-right">
 
             <gov-button :to="{ name: 'service-locations-edit', params: { serviceLocation: serviceLocation.id } }">
-              Edit service location
+              Edit support listing location
             </gov-button>
 
           </gov-grid-column>

--- a/src/views/services/Create.vue
+++ b/src/views/services/Create.vue
@@ -2,11 +2,11 @@
   <gov-width-container>
     <vue-headful :title="`${appName} - Add Service`" />
 
-    <gov-back-link :to="{ name: 'services-index' }">Back to services</gov-back-link>
+    <gov-back-link :to="{ name: 'services-index' }">Back to support listings</gov-back-link>
     <gov-main-wrapper>
       <gov-grid-row>
         <gov-grid-column width="full">
-          <gov-heading size="xl">Services</gov-heading>
+          <gov-heading size="xl">Support listings</gov-heading>
 
           <template v-if="!auth.isGlobalAdmin">
             <gov-body class="govuk-!-font-weight-bold">
@@ -18,11 +18,11 @@
               <li>The {{ form.type }} won't be made active until an admin has reviewed it.</li>
               <li>If there are any issues upon review, an admin will get directly in touch with you.</li>
               <li>You can return to edit this {{ form.type }} at any time.</li>
-              <li>If you would like your service to accept referrals through {{appName}}, please contact the team at <gov-link href="mailto:info@connectedtogether.org.uk">info@connectedtogether.org.uk</gov-link></li>
+              <li>If you would like your support listing to accept referrals through {{appName}}, please contact the team at <gov-link href="mailto:info@connectedtogether.org.uk">info@connectedtogether.org.uk</gov-link></li>
             </gov-list>
           </template>
 
-          <gov-heading size="m">Add service</gov-heading>
+          <gov-heading size="m">Add support listing</gov-heading>
 
           <gov-error-summary v-if="form.$errors.any()" title="Check for errors">
             <gov-list>
@@ -268,7 +268,7 @@ export default {
 
       if (data.data.is_national) {
         this.clearFormStore();
-        // Cannot add locations so go direct to Service view
+        // Cannot add locations so go direct to Support listing view
         this.$router.push({ path: `/services/${serviceId}` });
       } else {
         this.clearFormStore();
@@ -307,7 +307,7 @@ export default {
       this.$webStorage.set("serviceCreating", newData);
     },
     clearFormStore() {
-      // Clear the service store
+      // Clear the support listing store
       this.$webStorage.remove("serviceCreating");
       // Clear the tab index
       this.$webStorage.remove("activeTabIndex");

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -2,7 +2,7 @@
   <gov-width-container>
     <ck-loader v-if="loading" />
     <template v-else>
-      <vue-headful :title="`${appName} - Edit Service: ${service.name}`" />
+      <vue-headful :title="`${appName} - Edit Support listing: ${service.name}`" />
 
       <!-- Edit form -->
       <div>
@@ -10,7 +10,7 @@
         <gov-main-wrapper>
           <gov-grid-row>
             <gov-grid-column width="full">
-              <gov-heading size="xl">Services</gov-heading>
+              <gov-heading size="xl">Support listings</gov-heading>
 
               <gov-heading size="m">Edit {{ form.type }}</gov-heading>
 

--- a/src/views/services/Import.vue
+++ b/src/views/services/Import.vue
@@ -1,15 +1,15 @@
 <template>
     <gov-width-container>
-        <vue-headful :title="`${appName} - Import Services`" />
+        <vue-headful :title="`${appName} - Import Support listings`" />
 
         <gov-back-link :to="{ name: 'dashboard' }">Back to dashboard</gov-back-link>
         <gov-main-wrapper>
         <gov-grid-row>
             <gov-grid-column width="full">
 
-                <gov-heading size="xl">Bulk upload services</gov-heading>
+                <gov-heading size="xl">Bulk upload support listings</gov-heading>
                 <gov-body>
-                    <p>This tool allows you to upload the details of more than one service into the platform. You can add up to 5000 services in a single document.</p>
+                    <p>This tool allows you to upload the details of more than one support listing into the platform. You can add up to 5000 support listings in a single document.</p>
 
                     <p>The import tool requires all documents to be either in the .xls or .xlsx format. Please note that .csv files are not supported.</p>
 
@@ -20,7 +20,7 @@
 
                 <organisation-select-form
                   filter="is_admin"
-                  label="Select the Organisation to assign the Services to"
+                  label="Select the Organisation to assign the Support listings to"
                   v-model="organisationId"
                 />
 
@@ -118,7 +118,7 @@ export default {
       return this.uploadRows
         ? "Imported " +
             this.uploadRows +
-            (this.uploadRows === 1 ? " Service" : " Services")
+            (this.uploadRows === 1 ? " Support listing" : " Support listings")
         : null;
     },
     exampleSpreadsheetDownloadLink() {

--- a/src/views/services/Index.vue
+++ b/src/views/services/Index.vue
@@ -1,6 +1,6 @@
 <template>
   <gov-width-container>
-    <vue-headful :title="`${appName} - List Services`" />
+    <vue-headful :title="`${appName} - List Support listings`" />
 
     <gov-back-link :to="{ name: 'dashboard' }">Back to dashboard</gov-back-link>
 
@@ -8,13 +8,13 @@
       <gov-grid-row>
         <gov-grid-column width="full">
 
-          <gov-heading size="xl">Services</gov-heading>
+          <gov-heading size="xl">Support listings</gov-heading>
 
           <gov-grid-row>
             <gov-grid-column width="two-thirds">
               <ck-table-filters @search="onSearch">
                 <gov-form-group>
-                  <gov-label for="filter[name]">Service name</gov-label>
+                  <gov-label for="filter[name]">Support listing name</gov-label>
                   <gov-input v-model="filters.name" id="filter[name]" name="filter[name]" type="search"/>
                 </gov-form-group>
 
@@ -54,7 +54,7 @@
               </ck-table-filters>
             </gov-grid-column>
             <gov-grid-column v-if="auth.isOrganisationAdmin() || auth.isLocalAdmin" width="one-third">
-              <gov-button @click="onAddService" type="submit" success expand>Add service</gov-button>
+              <gov-button @click="onAddService" type="submit" success expand>Add support listing</gov-button>
               <gov-button :to="{name: 'services-import'}" type="submit" success expand>Bulk import</gov-button>
             </gov-grid-column>
           </gov-grid-row>

--- a/src/views/services/PreCreate.vue
+++ b/src/views/services/PreCreate.vue
@@ -3,13 +3,13 @@
     <vue-headful :title="`${appName} - Add Service`" />
 
     <gov-back-link :to="{ name: 'services-index' }">
-      Back to services
+      Back to support listings
     </gov-back-link>
 
     <gov-main-wrapper>
       <gov-grid-row>
         <gov-grid-column width="one-half">
-          <gov-heading size="xl">Add a new Service Page</gov-heading>
+          <gov-heading size="xl">Add a new Support listing Page</gov-heading>
 
           <gov-body>
             You’re about to add a service/club/activity/group/helpline/information/app/advice
@@ -19,11 +19,11 @@
           <gov-list bullet>
             <li>
               You will be asked to provide information a customer would want to
-              know about your service - make sure you have it to hand
+              know about your support listing - make sure you have it to hand
             </li>
             <li>
-              You can add as many services as you want - so please split your
-              services into multiple pages as appropriate
+              You can add as many support listings as you want - so please split your
+              support listings into multiple pages as appropriate
             </li>
             <li>
               When you are finished your page will be sent to the admin team for
@@ -37,7 +37,7 @@
           </gov-warning-text>
 
           <gov-button :to="{name: 'services-index'}">
-            Back to services
+            Back to support listings
           </gov-button><!--
           -->&nbsp;<!--
           --><gov-button :to="{ name: 'services-create' }">

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -1,6 +1,6 @@
 <template>
   <gov-width-container>
-    <gov-back-link :to="{ name: 'services-index' }">Back to services</gov-back-link>
+    <gov-back-link :to="{ name: 'services-index' }">Back to support listings</gov-back-link>
     <gov-main-wrapper>
       <ck-loader v-if="loading" />
       <gov-grid-row v-else>

--- a/src/views/services/forms/AdditionalInfoTab.vue
+++ b/src/views/services/forms/AdditionalInfoTab.vue
@@ -43,7 +43,7 @@
           <template slot="hint">
             <gov-hint for="is_free">
               Indicates whether your {{ type }} is completely free, or if some
-              elements of the service must be paid for. Users can filter their
+              elements of the support listing must be paid for. Users can filter their
               searches based on the answer you provide.
             </gov-hint>
             <gov-hint for="is_free">
@@ -87,7 +87,7 @@
         >
           <template slot="hint">
               <gov-hint for="testimonial">
-                Please enter a quote from a service user highlighting a positive outcome to
+                Please enter a quote from a support listing user highlighting a positive outcome to
                 help promote your good work. For example:
               </gov-hint>
               <gov-hint for="testimonial">

--- a/src/views/services/forms/DetailsTab.vue
+++ b/src/views/services/forms/DetailsTab.vue
@@ -125,7 +125,7 @@
           @input="$emit('update:is_national', $event); $emit('clear', 'is_national')"
           id="is_national"
           label="National?"
-          hint="Details if the service is only available at specific locations or can be accessed nationwide, e.g. via web or phone."
+          hint="Details if the support listing is only available at specific locations or can be accessed nationwide, e.g. via web or phone."
           :options="isNationalOptions"
           :error="errors.get('is_national')"
         />
@@ -264,7 +264,7 @@ export default {
   computed: {
     logoHelpHref() {
       const to = "info@connectedtogether.org.uk";
-      const subject = "Help uploading service logo";
+      const subject = "Help uploading support listing logo";
 
       return `mailto:${to}?subject=${encodeURIComponent(subject)}`;
     },

--- a/src/views/services/forms/WhoForTab.vue
+++ b/src/views/services/forms/WhoForTab.vue
@@ -15,7 +15,7 @@
           @input="$emit('update:age_group', $event); $emit('clear', 'criteria.age_group')"
           :error="errors.get('criteria.age_group')"
           id="criteria.age_group"
-          label="Age of service user (if applicable)"
+          label="Age of support listing user (if applicable)"
           :hint="`E.g “This ${type} is for people 16+” or “This ${type} is aimed at people nearing retirement”`"
         />
         <!-- /Age group -->

--- a/src/views/services/show/WhoForTab.vue
+++ b/src/views/services/show/WhoForTab.vue
@@ -4,7 +4,7 @@
     <gov-table>
       <template slot="body">
         <gov-table-row>
-          <gov-table-header scope="row" top>Age of service user</gov-table-header>
+          <gov-table-header scope="row" top>Age of support listing user</gov-table-header>
           <gov-table-cell>{{ service.criteria.age_group || "No specific requirement" }}</gov-table-cell>
         </gov-table-row>
         <gov-table-row>

--- a/src/views/stop-words/Edit.vue
+++ b/src/views/stop-words/Edit.vue
@@ -17,7 +17,7 @@
 
                 <gov-heading size="m">Edit Stop Words</gov-heading>
 
-                <gov-body>Update the stop words used when searching for services.</gov-body>
+                <gov-body>Update the stop words used when searching for support listings.</gov-body>
 
                 <stop-words-form
                   :errors="form.$errors"

--- a/src/views/thesaurus/Edit.vue
+++ b/src/views/thesaurus/Edit.vue
@@ -17,7 +17,7 @@
 
                 <gov-heading size="m">Edit Thesaurus</gov-heading>
 
-                <gov-body>Update the synonyms used when searching for services.</gov-body>
+                <gov-body>Update the synonyms used when searching for support listings.</gov-body>
                 <gov-body>
                   As all rows in a CSV must contain the same number of columns, the system will
                   strip out any blank cells. See the example below for reference:

--- a/src/views/users/Create.vue
+++ b/src/views/users/Create.vue
@@ -11,7 +11,7 @@
 
           <gov-heading size="m">Add user</gov-heading>
 
-          <gov-body>Create users to be able to acces the back-end of the {{appName}} service (deciding their permissions in what they have access to)</gov-body>
+          <gov-body>Create users to be able to acces the back-end of the {{appName}} support listing (deciding their permissions in what they have access to)</gov-body>
 
           <user-form
             :errors="form.$errors"

--- a/src/views/users/Edit.vue
+++ b/src/views/users/Edit.vue
@@ -10,7 +10,7 @@
           <gov-grid-column width="one-half">
             <gov-heading size="xl">Users</gov-heading>
             <gov-heading size="m">Edit user</gov-heading>
-            <gov-body>Edit users who can acces the back-end of the {{appName}} service (deciding their permissions in what they have access to)</gov-body>
+            <gov-body>Edit users who can acces the back-end of the {{appName}} support listing (deciding their permissions in what they have access to)</gov-body>
 
             <user-form
               :errors="form.$errors"

--- a/src/views/users/Index.vue
+++ b/src/views/users/Index.vue
@@ -49,7 +49,7 @@
                   </gov-form-group>
 
                   <gov-form-group>
-                    <gov-label for="filter[at_service]">Service</gov-label>
+                    <gov-label for="filter[at_service]">Support listing</gov-label>
                     <ck-loader v-if="loadingServices" />
                     <gov-select v-else v-model="filters.at_service" id="filter[at_service]" name="filter[at_service]" :options="services"/>
                   </gov-form-group>

--- a/src/views/users/forms/UserForm.vue
+++ b/src/views/users/forms/UserForm.vue
@@ -73,14 +73,14 @@
     <gov-list bullet>
       <li>
         <strong>Organisation admins:</strong>
-        Add services, add users, edit services, edit users, manage referrals
+        Add support listings, add users, edit support listings, edit users, manage referrals
       </li>
       <li>
-        <strong>Service admins:</strong>
-        Edit services, manage referrals
+        <strong>Support listing admins:</strong>
+        Edit support listings, manage referrals
       </li>
       <li>
-        <strong>Service workers:</strong>
+        <strong>Support listing workers:</strong>
         Manage referrals
       </li>
     </gov-list>


### PR DESCRIPTION
### Summary
https://trello.com/c/dSoG4tw0

- Replaced 'Connected Together' with 'Connect' globally
- Replacing info@connectedtogether.org.uk with hlp.admin.connect@nhs.net was already achieved in https://github.com/Healthy-London-Partnership/admin/pull/30
- Replaced 'Service' and 'Services' with 'Support listing' and 'Support listings' globally in copy. The word 'service' is still used in code and within URIs.

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
NA

### Notes
The default type of support listing is still 'service' as this is used as an ID within the code and on the API.
